### PR TITLE
feat: add Cardputer ADV support

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# Palnagotchi for M5 Cardputer
+# Palnagotchi for M5Stack
 
 ![Palnagotchi](https://github.com/viniciusbo/m5-palnagotchi/blob/master/palnagotchi.jpg?raw=true)
 
@@ -11,6 +11,7 @@ The Pwngrid works by sending Wifi beacon frames with a JSON serialized payload i
 ## Supported devices
 
 - Cardputer
+- Cardputer ADV
 - StickC Plus2
 - StickC (untested)
 - AtomS3
@@ -22,7 +23,7 @@ The Pwngrid works by sending Wifi beacon frames with a JSON serialized payload i
 
 - Run the app to start advertisement.
 - Button layouts:
-  - Cardputer: ESC or m toggles the menu. Use arrow keys or tab to navigate and OK to select option. Esc or m to go back to main menu.
+  - Cardputer / Cardputer ADV: ESC or m toggles the menu. Use arrow keys or tab to navigate and OK to select option. Esc or m to go back to main menu.
   - StickC Plus2: Long press M5 button to toggle menu. Use top and bottom keys to navigate and M5 button (short press) to select option.
   - AtomS3(R): Long press display to toggle menu. Use double/triple tap display to navigate and short press display to select option.
   - Dial: Long press M5 button to toggle menu. Use rotary encoder to navigate. Short press M5 button to select.


### PR DESCRIPTION
![IMG_2235](https://github.com/user-attachments/assets/166ec8f7-7ed7-4c37-bb7c-f95fceddfd1c)

## Summary
- Add Cardputer ADV as a supported device in the README
- The M5Cardputer library (v1.1.0+) handles Cardputer ADV at runtime via M5Unified board detection — no code changes needed
- Update button layout docs to cover both Cardputer variants

Closes https://github.com/viniciusbo/m5-palnagotchi/issues/8

## Test plan
- [ ] Verify firmware runs on Cardputer ADV hardware
- [ ] Verify existing Cardputer functionality is unaffected